### PR TITLE
fix: Séparer data et options dans ConfigFlow

### DIFF
--- a/custom_components/SmartHRT/__init__.py
+++ b/custom_components/SmartHRT/__init__.py
@@ -86,5 +86,30 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Fonction qui force le rechargement des entités associées à une configEntry"""
-    await hass.config_entries.async_reload(entry.entry_id)
+    """Applique les changements d'options sans recharger l'intégration.
+
+    Les options dynamiques (target_hour, recoverycalc_hour, tsp) peuvent
+    être appliquées à chaud via le coordinateur, évitant un rechargement
+    complet qui réinitialiserait l'état de la machine à états.
+    """
+    from .const import CONF_TARGET_HOUR, CONF_RECOVERYCALC_HOUR, CONF_TSP
+
+    coordinator = hass.data[DOMAIN][entry.entry_id].get(DATA_COORDINATOR)
+    if not coordinator:
+        _LOGGER.warning("Coordinator not found for entry %s", entry.entry_id)
+        return
+
+    options = entry.options
+    _LOGGER.debug("Applying options update: %s", options)
+
+    # Appliquer les changements d'options au coordinateur
+    if CONF_TSP in options:
+        coordinator.set_tsp(options[CONF_TSP])
+
+    if CONF_TARGET_HOUR in options:
+        target_time = coordinator._parse_time(options[CONF_TARGET_HOUR])
+        coordinator.set_target_hour(target_time)
+
+    if CONF_RECOVERYCALC_HOUR in options:
+        recoverycalc_time = coordinator._parse_time(options[CONF_RECOVERYCALC_HOUR])
+        coordinator.set_recoverycalc_hour(recoverycalc_time)

--- a/custom_components/SmartHRT/coordinator.py
+++ b/custom_components/SmartHRT/coordinator.py
@@ -188,12 +188,22 @@ class SmartHRTCoordinator:
             hass, self.STORAGE_VERSION, f"{DOMAIN}.{entry.entry_id}"
         )
 
+        # Lecture des options avec fallback sur data pour la rétrocompatibilité
+        # Les valeurs dynamiques (tsp, target_hour, recoverycalc_hour) sont dans options
+        # Les valeurs statiques (name, sensors) restent dans data
         self.data = SmartHRTData(
             name=entry.data.get(CONF_NAME, "SmartHRT"),
-            tsp=entry.data.get(CONF_TSP, DEFAULT_TSP),
-            target_hour=self._parse_time(entry.data.get(CONF_TARGET_HOUR, "06:00:00")),
+            tsp=entry.options.get(CONF_TSP, entry.data.get(CONF_TSP, DEFAULT_TSP)),
+            target_hour=self._parse_time(
+                entry.options.get(
+                    CONF_TARGET_HOUR, entry.data.get(CONF_TARGET_HOUR, "06:00:00")
+                )
+            ),
             recoverycalc_hour=self._parse_time(
-                entry.data.get(CONF_RECOVERYCALC_HOUR, DEFAULT_RECOVERYCALC_HOUR)
+                entry.options.get(
+                    CONF_RECOVERYCALC_HOUR,
+                    entry.data.get(CONF_RECOVERYCALC_HOUR, DEFAULT_RECOVERYCALC_HOUR),
+                )
             ),
         )
 


### PR DESCRIPTION
- Séparer les clés statiques (data) et dynamiques (options) selon les bonnes pratiques HA
- data : CONF_NAME, CONF_SENSOR_INTERIOR_TEMP, CONF_PHONE_ALARM (configuration initiale)
- options : CONF_TARGET_HOUR, CONF_RECOVERYCALC_HOUR, CONF_TSP (réglages dynamiques)
- Modifier update_listener pour appliquer les options à chaud sans rechargement
- Le coordinateur lit options avec fallback sur data pour rétrocompatibilité
- Mise à jour des tests pour refléter le nouveau comportement