### PR TITLE
fix(switch): persiste les modes adaptatif et chauffage intelligent

### DIFF
--- a/custom_components/SmartHRT/coordinator.py
+++ b/custom_components/SmartHRT/coordinator.py
@@ -2515,11 +2515,13 @@ class SmartHRTCoordinator(DataUpdateCoordinator[SmartHRTData]):
         """Active/désactive le mode chauffage intelligent."""
         self.data.smartheating_mode = value
         self.async_set_updated_data(self.data)
+        self.hass.async_create_task(self._save_learned_data())
 
     def set_recovery_adaptive_mode(self, value: bool) -> None:
         """Active/désactive le mode adaptatif."""
         self.data.recovery_adaptive_mode = value
         self.async_set_updated_data(self.data)
+        self.hass.async_create_task(self._save_learned_data())
 
     def set_adaptive_mode(self, value: bool) -> None:
         """Alias pour set_recovery_adaptive_mode."""

--- a/custom_components/SmartHRT/data_model.py
+++ b/custom_components/SmartHRT/data_model.py
@@ -294,6 +294,9 @@ class SmartHRTData(BaseModel):
         # État machine
         "current_state",
         "stop_lag_duration",
+        # Modes utilisateur
+        "smartheating_mode",
+        "recovery_adaptive_mode",
         # Heures configurées
         "target_hour",
         "recoverycalc_hour",

--- a/custom_components/SmartHRT/switch.py
+++ b/custom_components/SmartHRT/switch.py
@@ -84,13 +84,11 @@ class SmartHRTSmartHeatingSwitch(SmartHRTBaseSwitch):
         self._attr_translation_key = "smartheating_mode"
         self._attr_unique_id = f"{self._device_id}_smartheating_mode"
 
+    _attr_icon = "mdi:home-thermometer"
+
     @property
     def is_on(self) -> bool:
         return self.coordinator.data.smartheating_mode
-
-    @property
-    def icon(self) -> str | None:
-        return "mdi:home-thermometer" if self.is_on else "mdi:home-thermometer-outline"
 
     async def async_turn_on(self, **kwargs) -> None:
         """Activer le mode chauffage intelligent"""
@@ -117,13 +115,11 @@ class SmartHRTAdaptiveSwitch(SmartHRTBaseSwitch):
         self._attr_translation_key = "adaptive_mode"
         self._attr_unique_id = f"{self._device_id}_adaptive_mode"
 
+    _attr_icon = "mdi:brain"
+
     @property
     def is_on(self) -> bool:
         return self.coordinator.data.recovery_adaptive_mode
-
-    @property
-    def icon(self) -> str | None:
-        return "mdi:brain" if self.is_on else "mdi:brain-off-outline"
 
     async def async_turn_on(self, **kwargs) -> None:
         """Activer le mode adaptatif"""


### PR DESCRIPTION
- Ajoute smartheating_mode et recovery_adaptive_mode dans _PERSISTENT_FIELDS pour qu'ils soient inclus dans as_dict() lors de la sérialisation
- Appelle _save_learned_data() dans set_smartheating_mode() et set_recovery_adaptive_mode() pour écrire immédiatement en stockage
- Remplace les icônes dynamiques invalides (mdi:brain-off-outline) par des _attr_icon statiques : HA gère nativement le grisage au state OFF